### PR TITLE
Upgrade node-sass to 2.0.1 and react-hot-loader to 1.1

### DIFF
--- a/dev-tools.js
+++ b/dev-tools.js
@@ -24,7 +24,7 @@ var webpackServer = new WebpackDevServer(webpack(webpackConfig), {
 
 // Render scss files
 var renderSass = function(filename) {
-  sass.renderFile({
+  sass.render({
     file: __dirname + '/style/main.scss',
     outFile: __dirname + '/public/css/main.css',
     sourceMap: true,

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "jsx-loader": "^0.12.2",
     "livereload": "^0.3.4",
     "node-notifier": "^4.0.2",
-    "node-sass": "^1.2.3",
+    "node-sass": "^2.0.1",
     "nodemon": "^1.2.1",
-    "react-hot-loader": "^0.5.0",
+    "react-hot-loader": "^1.1.0",
     "watch": "^0.13.0",
     "webpack": "^1.4.13",
     "webpack-dev-server": "^1.6.6"


### PR DESCRIPTION
Upon `npm install` `node-sass` was causing `Error: Module did not self-register.` errors on my system.
`react-hot-loader` generated a warning and wanted to be upgraded to 1.1 so I have updated things  to get it to work out of the box:
```
"node-sass": "^2.0.1",
"react-hot-loader": "^1.1.0",
```
